### PR TITLE
Made port scanning only occur if someone is subscribed to the event. …

### DIFF
--- a/Lego.Ev3.Core/Brick.cs
+++ b/Lego.Ev3.Core/Brick.cs
@@ -194,6 +194,7 @@ namespace Lego.Ev3.Core
 
 		private async Task PollSensorsAsync()
 		{
+            if (BrickChanged.GetInvocationList().Length == 0) return;
 			bool changed = false;
 			const int responseSize = 11;
 			int index = 0;


### PR DESCRIPTION
…This frees up serial communication significantly in the event nobody is interested in polling the sensors, I.E. when we want to send files or do other potentially time-sensitive tasks.